### PR TITLE
adjust log_actions method for Django 5.1.7 compatibility

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Version 1.4.0
+-------------
+
+- Updated `ChangedLogEntryManager` and `NoLogEntryManager` to handle the removal of the `single_object` argument in Django 5.1.7.
+- Ensured compatibility with Django versions both before and after 5.1.7.
+
 1.3.0 (2024-08-10)
 ------------------
 * Added support for Django 5.1

--- a/README.rst
+++ b/README.rst
@@ -98,3 +98,8 @@ To run tests for specific versions e.g. Python 3.10 and Django 4.2:
 .. code-block:: bash
 
     tox -e py310-django42
+
+Compatibility
+=============
+
+This package has been updated to handle the removal of the `single_object` argument in Django 5.1.7. The code conditionally includes or excludes this argument based on the Django version to ensure compatibility with versions both before and after Django 5.1.7.

--- a/django_admin_logs/models.py
+++ b/django_admin_logs/models.py
@@ -44,19 +44,27 @@ class ChangedLogEntryManager(LogEntryManager):
             )
 
     def log_actions(
-        self, user_id, queryset, action_flag, change_message="", *, single_object=False
+        self, user_id, queryset, action_flag, change_message="", single_object=False
     ):
         # Check whether this is a log with no changes that should be ignored
         if action_flag == models.CHANGE and not change_message:
             return None
         else:  # Log as normal
-            return super().log_actions(
-                user_id,
-                queryset,
-                action_flag,
-                change_message,
-                single_object=single_object,
-            )
+            if django.VERSION < (5, 1, 7):
+                return super().log_actions(
+                    user_id,
+                    queryset,
+                    action_flag,
+                    change_message,
+                    single_object=single_object,
+                )
+            else:
+                return super().log_actions(
+                    user_id,
+                    queryset,
+                    action_flag,
+                    change_message,
+                )
 
 
 class NoLogEntryManager(LogEntryManager):
@@ -68,6 +76,8 @@ class NoLogEntryManager(LogEntryManager):
 
     def log_actions(self, *args, **kwargs):
         # No logging
+        if django.VERSION < (5, 1, 7):
+            kwargs.pop('single_object', None)
         return None
 
     def get_queryset(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "django-admin-logs"
 description = "View, delete or disable Django admin log entries."
-version = "1.3.0"
+version = "1.4.0"
 authors = [
     { name="Adam Radwon" },
 ]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -40,9 +40,7 @@ class LogEntryManagerTest(TestCase):
                 CHANGE,
             )
         else:
-            log_entry = LogEntry.objects.log_actions(
-                self.user.pk, [self.user], CHANGE, single_object=True
-            )
+            log_entry = LogEntry.objects.log_actions(self.user.pk, [self.user], CHANGE)
         # Ensure the log entry was created for the action
         self.assertEqual(log_entry, LogEntry.objects.first())
         self.assertEqual(LogEntry.objects.count(), 1)
@@ -76,7 +74,7 @@ class ChangedLogEntryManagerTest(TestCase):
             )
         else:
             log_entry = LogEntry.objects.log_actions(
-                self.user.pk, [self.user], CHANGE, "", single_object=True
+                self.user.pk, [self.user], CHANGE, ""
             )
         # Ensure there was no log entry created for the action
         self.assertEqual(log_entry, None)
@@ -93,9 +91,29 @@ class ChangedLogEntryManagerTest(TestCase):
             )
         else:
             log_entry = LogEntry.objects.log_actions(
-                self.user.pk, [self.user], CHANGE, "Changed user", single_object=True
+                self.user.pk, [self.user], CHANGE, "Changed user"
             )
         self.assertEqual(log_entry, LogEntry.objects.first())
+        self.assertEqual(LogEntry.objects.count(), 1)
+
+    @mock.patch("django_admin_logs.settings.DJANGO_ADMIN_LOGS_IGNORE_UNCHANGED", True)
+    def test_log_actions_with_single_object(self):
+        """Test log_actions with single_object argument for Django < 5.1.7."""
+        # Re-run the app config ready() method to use the test settings
+        apps.get_app_config("django_admin_logs").ready()
+        # Ensure there are no log entries yet
+        self.assertEqual(LogEntry.objects.count(), 0)
+        # Create a log entry with changes
+        if django.VERSION < (5, 1, 7):
+            log_entry = LogEntry.objects.log_actions(
+                self.user.pk, [self.user], CHANGE, "Changed user", single_object=True
+            )
+        else:
+            log_entry = LogEntry.objects.log_actions(
+                self.user.pk, [self.user], CHANGE, "Changed user"
+            )
+        # Ensure the log entry was created for the action
+        self.assertIsNotNone(log_entry)
         self.assertEqual(LogEntry.objects.count(), 1)
 
 
@@ -125,9 +143,43 @@ class NoLogEntryManagerTest(TestCase):
                 CHANGE,
             )
         else:
+            log_entry = LogEntry.objects.log_actions(self.user.pk, [self.user], CHANGE)
+        # Ensure there was no log entry created for the action
+        self.assertEqual(log_entry, None)
+        self.assertEqual(LogEntry.objects.count(), 0)
+
+    @mock.patch("django_admin_logs.settings.DJANGO_ADMIN_LOGS_ENABLED", False)
+    def test_no_log_actions_with_single_object(self):
+        """Test no log_actions with single_object argument for Django < 5.1.7."""
+        # Re-run the app config ready() method to use the test settings
+        apps.get_app_config("django_admin_logs").ready()
+        # Ensure there are no log entries yet
+        self.assertEqual(LogEntry.objects.count(), 0)
+        # Attempt to create a log entry when admin logs are disabled
+        if django.VERSION < (5, 1, 7):
             log_entry = LogEntry.objects.log_actions(
                 self.user.pk, [self.user], CHANGE, single_object=True
             )
+        else:
+            log_entry = LogEntry.objects.log_actions(self.user.pk, [self.user], CHANGE)
+        # Ensure there was no log entry created for the action
+        self.assertEqual(log_entry, None)
+        self.assertEqual(LogEntry.objects.count(), 0)
+
+    @mock.patch("django_admin_logs.settings.DJANGO_ADMIN_LOGS_ENABLED", False)
+    def test_no_log_actions_with_kwargs(self):
+        """Test log_actions with kwargs for Django < 5.1.7."""
+        # Re-run the app config ready() method to use the test settings
+        apps.get_app_config("django_admin_logs").ready()
+        # Ensure there are no log entries yet
+        self.assertEqual(LogEntry.objects.count(), 0)
+        # Attempt to create a log entry when admin logs are disabled
+        if django.VERSION < (5, 1, 7):
+            log_entry = LogEntry.objects.log_actions(
+                self.user.pk, [self.user], CHANGE, single_object=True
+            )
+        else:
+            log_entry = LogEntry.objects.log_actions(self.user.pk, [self.user], CHANGE)
         # Ensure there was no log entry created for the action
         self.assertEqual(log_entry, None)
         self.assertEqual(LogEntry.objects.count(), 0)


### PR DESCRIPTION
## Summary of Changes

- Updated `ChangedLogEntryManager` and `NoLogEntryManager` to handle the removal of the `single_object` argument in Django 5.1.7.
- Ensured compatibility with Django versions both before and after 5.1.7.
- Updated test cases to reflect these changes.
- Added compatibility notes to `README.rst`.
- Updated `CHANGELOG.rst` with details of the changes.
- Bumped version number to 1.4.0 in `pyproject.toml`.

## Motivation behind the changes

It seems that Django 5.1.7 [removed](https://code.djangoproject.com/ticket/36217) the single_object arg and this is causing this app to fail.

```
    def log_actions(
        self, user_id, queryset, action_flag, change_message="", *, single_object=False
    ):
        # Check whether this is a log with no changes that should be ignored
        if action_flag == models.CHANGE and not change_message:
            return None
        else:  # Log as normal
>           return super().log_actions(
                user_id,
                queryset,
                action_flag,
                change_message,
                single_object=single_object,
            )
E           TypeError: LogEntryManager.log_actions() got an unexpected keyword argument 'single_object'

.venv\Lib\site-packages\django_admin_logs\models.py:53: TypeError
```